### PR TITLE
Bugfix: replace `Sort::Date` from `"date"` to `"id"`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -60,7 +60,7 @@ impl Display for Sort {
         match self {
             Sort::Comments => write!(f, "comments"),
             Sort::Size => write!(f, "size"),
-            Sort::Date => write!(f, "date"),
+            Sort::Date => write!(f, "id"),
             Sort::Seeders => write!(f, "seeders"),
             Sort::Leechers => write!(f, "leechers"),
             Sort::Downloads => write!(f, "downloads"),


### PR DESCRIPTION
I encountered an issue using this crate to develop my [nyaa.si](https://nyaa.si/?form=MG0AV3) search app: `Sort::Date` no longer returns any results. It appears the site's sorting keyword has been updated from `"date"` to `"id"`. This PR addresses that change.

Here's the pictures explaining the issue:
![image](https://github.com/user-attachments/assets/279529a9-aeea-4e08-9996-0aaddea1da4c)
![image](https://github.com/user-attachments/assets/65806784-b275-4565-9149-e62d5b7fc6dd)
