### PR TITLE
Bugfix: replace Query.category in QueryBuilder.build() from `C::default()` to `self.category`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -87,9 +87,9 @@ impl From<u8> for Filter {
     }
 }
 
-impl From<Filter> for u8 {
-    fn from(i: Filter) -> Self {
-        match i {
+impl Into<u8> for Filter {
+    fn into(self) -> u8 {
+        match self {
             Filter::NoFilter => 0,
             Filter::NoRemakes => 1,
             Filter::TrustedOnly => 2,

--- a/src/query.rs
+++ b/src/query.rs
@@ -87,6 +87,7 @@ impl From<u8> for Filter {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<u8> for Filter {
     fn into(self) -> u8 {
         match self {

--- a/src/query.rs
+++ b/src/query.rs
@@ -60,7 +60,7 @@ impl Display for Sort {
         match self {
             Sort::Comments => write!(f, "comments"),
             Sort::Size => write!(f, "size"),
-            Sort::Date => write!(f, "date"),
+            Sort::Date => write!(f, "id"),
             Sort::Seeders => write!(f, "seeders"),
             Sort::Leechers => write!(f, "leechers"),
             Sort::Downloads => write!(f, "downloads"),

--- a/src/query.rs
+++ b/src/query.rs
@@ -186,7 +186,7 @@ impl<C: Category> QueryBuilder<C> {
             sort: self.sort,
             sort_order: self.sort_order,
             filter: self.filter,
-            category: C::default(),
+            category: self.category,
         }
     }
 
@@ -218,5 +218,21 @@ impl<C: Category> QueryBuilder<C> {
     pub fn category(mut self, category: C) -> QueryBuilder<C> {
         self.category = category;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NyaaCategory;
+
+    #[test]
+    fn test_build() {
+        let query = QueryBuilder::new()
+            .search("frieren")
+            .sort(Sort::Date)
+            .category(NyaaCategory::Anime)
+            .build();
+        assert_eq!(query.to_string(), format!("q={}&p={}&s={}&o={}&f={}&c={}", "frieren", 1, "id", "desc", 0, "1_0"))
     }
 }


### PR DESCRIPTION
Sorry for the commits being messed up.

This PR contains two main updates:
- Bugfix: replace `Query.category` in `QueryBuilder.build()` from `C::default` to `self.category`
- Refactor: replace Impl `From <Filter> for u8` into `Into<u8> for Filter`

For the bugfix, there was an issue of QueryBuilder.build() always returning `"...&c=0_0"`.
For the refactor, `Into<u8> for Filter` Impl would represent better interaction than `From<Filter> for u8`.